### PR TITLE
compat fixes for py 38 and 39

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ ENV/
 
 .idea
 *.iml
+
+# coveralls
+.coveralls.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ matrix:
   include:
   - python: 3.6
   - python: 3.7
+  - python: 3.8
+  - python: 3.9
     dist: xenial
     sudo: true
 install: pip install -U tox-travis

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,8 +2,10 @@ wheel==0.33.1
 flake8==3.7.7
 tox==3.7.0
 coverage==4.5.2
+pyyaml==6.0.0
 coveralls==1.6.0
 pytest==4.3.0
 pytest-cov==2.6.1
 pytest-runner==4.4
 twine==1.13.0
+pyspark>=2.3

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -139,3 +139,17 @@ def test_parse_complex_type_dc():
 
     assert transform(ComplexDC) == COMPLEX_STRUCT
     assert transform(Complex) == transform(ComplexDC)
+
+
+@skip_dc
+def test_retains_dict_dc():
+    from dataclasses import dataclass
+
+    @struct
+    @dataclass
+    class PlainDC:
+        a: str
+        b: int
+        c: bool
+
+    assert hasattr(PlainDC("a", 1, True), "__dict__")

--- a/tinsel/lib.py
+++ b/tinsel/lib.py
@@ -25,12 +25,18 @@ def struct(cls: type) -> type:
     """
     Marks NamedTuple as suitable for ``tinsel.transform``
 
-    :param cls: Typed NamedTuple
+    :param cls: Typed NamedTuple, or Dataclass
     """
     if not is_container(cls):
-        raise ValueError(f"Only NamedTuple instances can be decorated with @struct, not {cls.__name__}")
+        raise ValueError(f"Only NamedTuple and Dataclass instances can be decorated with @struct, not {cls.__name__}")
+
+    newdict = dict(__pyspark_struct__=..., **cls.__dict__)
+    # These are class-bound, let Python recreate them so dataclasses still work
+    newdict.pop('__dict__', None)
+    newdict.pop('__weakref__', None)
+
     # Overwrite type with augmented one
-    return type(cls.__name__, cls.__bases__, dict(__pyspark_struct__=..., **cls.__dict__))
+    return type(cls.__name__, cls.__bases__, newdict)
 
 
 def check_pyspark_struct(cls: type):

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,10 @@
 [tox]
-envlist = py36, py37, flake8
+envlist = py36, py37, py38, py39, flake8
 
 [travis]
 python =
+    3.9: py39
+    3.8: py38
     3.7: py37
     3.6: py36
 


### PR DESCRIPTION
in higher versions of python the dataclasses wrapper doesn't work, due to overwriting the `__dict__` which apparently dataclasses need to generate automatically:
```python
spark.createDataFrame([PlainDC("a", 1, True)], schema=transform(PlainDC))

...

<env>/lib/python3.9/site-packages/pyspark/sql/types.py in verify_struct(obj)
   1699                 for v, (_, verifier) in zip(obj, verifiers):
   1700                     verifier(v)
-> 1701             elif hasattr(obj, "__dict__"):
   1702                 d = obj.__dict__
   1703                 for f, verifier in verifiers:

TypeError: descriptor '__dict__' for 'PlainDC' objects doesn't apply to a 'PlainDC' object
```

Couldn't find where to submit an issue, but here's a PR to enable compatibility with more versions of python.

Also I couldn't get tests + tox to work without adding some stuff to the requirements-dev file.